### PR TITLE
chore: upgrade dinero.js to v2.0.0 stable

### DIFF
--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -19,7 +19,6 @@
   },
   "dependencies": {
     "@ai-sdk/react": "^3.0.66",
-    "@dinero.js/currencies": "2.0.0-alpha.14",
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
@@ -65,7 +64,7 @@
     "date-fns": "^3.3.1",
     "date-fns-tz": "^3.2.0",
     "debounce": "^2.1.0",
-    "dinero.js": "2.0.0-alpha.14",
+    "dinero.js": "2.0.0",
     "flags": "^4.0.2",
     "framer-motion": "^11.0.8",
     "geist": "^1.3.1",

--- a/apps/nextjs/src/components/forms/items-fields.tsx
+++ b/apps/nextjs/src/components/forms/items-fields.tsx
@@ -1,5 +1,5 @@
 "use client"
-import * as currencies from "@dinero.js/currencies"
+import * as currencies from "dinero.js/currencies"
 import { AnimatePresence, motion } from "framer-motion"
 import { ChevronDown, LayoutGrid, Settings, Trash2, X } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"

--- a/apps/nextjs/src/components/onboarding/steps/template-plan-step.tsx
+++ b/apps/nextjs/src/components/onboarding/steps/template-plan-step.tsx
@@ -1,4 +1,4 @@
-import * as currencies from "@dinero.js/currencies"
+import * as currencies from "dinero.js/currencies"
 import { type StepComponentProps, useOnboarding } from "@onboardjs/react"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import type { Currency, PaymentProvider } from "@unprice/db/validators"

--- a/internal/db/package.json
+++ b/internal/db/package.json
@@ -33,7 +33,6 @@
   },
   "dependencies": {
     "@auth/core": "^0.34.1",
-    "@dinero.js/currencies": "2.0.0-alpha.14",
     "@neondatabase/serverless": "^0.10.3",
     "@t3-oss/env-core": "^0.12.0",
     "@unprice/config": "workspace:^",
@@ -42,7 +41,7 @@
     "base-x": "^4.0.0",
     "date-fns": "^3.3.1",
     "date-fns-tz": "^3.2.0",
-    "dinero.js": "2.0.0-alpha.14",
+    "dinero.js": "2.0.0",
     "drizzle-orm": "^0.44.5",
     "drizzle-zod": "^0.5.1",
     "random-word-slugs": "^0.1.7",

--- a/internal/db/src/utils.ts
+++ b/internal/db/src/utils.ts
@@ -1,4 +1,4 @@
-import * as currencies from "@dinero.js/currencies"
+import * as currencies from "dinero.js/currencies"
 import {
   type Dinero,
   add,

--- a/internal/db/src/validators/planVersionFeatures.ts
+++ b/internal/db/src/validators/planVersionFeatures.ts
@@ -1,4 +1,4 @@
-import * as currencies from "@dinero.js/currencies"
+import * as currencies from "dinero.js/currencies"
 import { dinero } from "dinero.js"
 import { createInsertSchema, createSelectSchema } from "drizzle-zod"
 import * as z from "zod"

--- a/internal/db/src/validators/subscriptions/prices.test.ts
+++ b/internal/db/src/validators/subscriptions/prices.test.ts
@@ -1,7 +1,7 @@
 import { dinero, toDecimal } from "dinero.js"
 import { describe, expect, it } from "vitest"
 
-import * as currencies from "@dinero.js/currencies"
+import * as currencies from "dinero.js/currencies"
 import type { Feature } from "../features"
 import type { PlanVersionFeature } from "../planVersionFeatures"
 import type { PlanVersionExtended } from "../planVersions"

--- a/internal/db/src/validators/subscriptions/prices.ts
+++ b/internal/db/src/validators/subscriptions/prices.ts
@@ -1,4 +1,4 @@
-import * as currencies from "@dinero.js/currencies"
+import * as currencies from "dinero.js/currencies"
 import type { Dinero } from "dinero.js"
 import { add, dinero, isZero, multiply, toDecimal, trimScale } from "dinero.js"
 import { z } from "zod"

--- a/internal/db/src/validators/subscriptions/waterfall.test.ts
+++ b/internal/db/src/validators/subscriptions/waterfall.test.ts
@@ -1,4 +1,4 @@
-import * as currencies from "@dinero.js/currencies"
+import * as currencies from "dinero.js/currencies"
 import { dinero } from "dinero.js"
 import { describe, expect, it } from "vitest"
 import type { UsageGrant } from "./prices"

--- a/internal/trpc/package.json
+++ b/internal/trpc/package.json
@@ -29,7 +29,6 @@
     "with-env": "infisical run --env=preview --path=/app --"
   },
   "dependencies": {
-    "@dinero.js/currencies": "2.0.0-alpha.14",
     "@potatohd/trpc-openapi": "^1.2.3",
     "@t3-oss/env-core": "^0.12.0",
     "@trpc/server": "11.5.0",
@@ -51,7 +50,7 @@
     "@vercel/functions": "^1.0.2",
     "date-fns": "^3.3.1",
     "date-fns-tz": "^3.2.0",
-    "dinero.js": "2.0.0-alpha.14",
+    "dinero.js": "2.0.0",
     "server-only": "^0.0.1",
     "superjson": "2.2.1",
     "uuid-random": "^1.3.2",

--- a/internal/trpc/src/router/lambda/analytics/getOverviewStats.ts
+++ b/internal/trpc/src/router/lambda/analytics/getOverviewStats.ts
@@ -1,4 +1,4 @@
-import * as currencies from "@dinero.js/currencies"
+import * as currencies from "dinero.js/currencies"
 import { type Interval, prepareInterval, statsSchema } from "@unprice/analytics"
 import { currencySymbol } from "@unprice/db/utils"
 import { calculateFlatPricePlan } from "@unprice/db/validators"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,7 +172,7 @@ importers:
     devDependencies:
       mint:
         specifier: ^4.2.279
-        version: 4.2.354(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/node@20.19.33)(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
+        version: 4.2.354(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/node@20.11.24)(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))(typescript@5.9.3)
 
   apps/lakehouse-api:
     devDependencies:
@@ -185,9 +185,6 @@ importers:
       '@ai-sdk/react':
         specifier: ^3.0.66
         version: 3.0.88(react@18.3.1)(zod@3.25.76)
-      '@dinero.js/currencies':
-        specifier: 2.0.0-alpha.14
-        version: 2.0.0-alpha.14
       '@dnd-kit/core':
         specifier: ^6.1.0
         version: 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -324,8 +321,8 @@ importers:
         specifier: ^2.1.0
         version: 2.2.0
       dinero.js:
-        specifier: 2.0.0-alpha.14
-        version: 2.0.0-alpha.14
+        specifier: 2.0.0
+        version: 2.0.0
       flags:
         specifier: ^4.0.2
         version: 4.0.3(@opentelemetry/api@1.9.0)(next@14.2.32(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -561,9 +558,6 @@ importers:
       '@auth/core':
         specifier: ^0.34.1
         version: 0.34.3(nodemailer@7.0.13)
-      '@dinero.js/currencies':
-        specifier: 2.0.0-alpha.14
-        version: 2.0.0-alpha.14
       '@neondatabase/serverless':
         specifier: ^0.10.3
         version: 0.10.4
@@ -589,8 +583,8 @@ importers:
         specifier: ^3.2.0
         version: 3.2.0(date-fns@3.6.0)
       dinero.js:
-        specifier: 2.0.0-alpha.14
-        version: 2.0.0-alpha.14
+        specifier: 2.0.0
+        version: 2.0.0
       drizzle-orm:
         specifier: ^0.44.5
         version: 0.44.7(@cloudflare/workers-types@4.20260217.0)(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(@upstash/redis@1.36.2)(gel@2.2.0)
@@ -922,9 +916,6 @@ importers:
 
   internal/trpc:
     dependencies:
-      '@dinero.js/currencies':
-        specifier: 2.0.0-alpha.14
-        version: 2.0.0-alpha.14
       '@potatohd/trpc-openapi':
         specifier: ^1.2.3
         version: 1.2.3(@trpc/server@11.5.0(typescript@5.9.3))(@types/node@20.19.33)(zod@3.25.76)
@@ -989,8 +980,8 @@ importers:
         specifier: ^3.2.0
         version: 3.2.0(date-fns@3.6.0)
       dinero.js:
-        specifier: 2.0.0-alpha.14
-        version: 2.0.0-alpha.14
+        specifier: 2.0.0
+        version: 2.0.0
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
@@ -1157,10 +1148,10 @@ importers:
         version: 7.71.1(react@18.3.1)
       tailwindcss:
         specifier: 3.4.1
-        version: 3.4.1(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))
+        version: 3.4.1(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3)))
+        version: 1.0.7(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3)))
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -1280,10 +1271,10 @@ importers:
         version: 3.0.0
       '@tailwindcss/forms':
         specifier: ^0.5.7
-        version: 0.5.11(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3)))
+        version: 0.5.11(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3)))
       '@tailwindcss/typography':
         specifier: ^0.5.13
-        version: 0.5.19(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3)))
+        version: 0.5.19(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3)))
       autoprefixer:
         specifier: ^10.4.18
         version: 10.4.24(postcss@8.4.35)
@@ -1292,10 +1283,10 @@ importers:
         version: 8.4.35
       tailwindcss:
         specifier: 3.4.1
-        version: 3.4.1(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))
+        version: 3.4.1(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3)))
+        version: 1.0.7(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3)))
     devDependencies:
       '@unprice/tsconfig':
         specifier: workspace:*
@@ -1913,15 +1904,6 @@ packages:
     resolution: {integrity: sha512-KvmOiQdpbamFziqnzzgqBm6RjfGhLJimBBYEOVriTxCPtVJuBIFm34xZllM36OQzPZIWpWBP+2/UnOyRG5smUg==}
     engines: {node: '>=14'}
     hasBin: true
-
-  '@dinero.js/calculator-number@2.0.0-alpha.14':
-    resolution: {integrity: sha512-Vmlu6eXNtkFU2cqlrpqfq8KQP9onALf8Es2d34liVa3k3RHjuhizgFUU3V3/tsjOu5WekZq+gYPOr58XVTkB7A==}
-
-  '@dinero.js/core@2.0.0-alpha.14':
-    resolution: {integrity: sha512-CtKELJ783joUbaU62fRM2xDXb4XYSy0MgOuIkPWgVOS3SYKKb6+2Ec9bNlvrW8lsPROz/RsvCuYVTphrZ79twg==}
-
-  '@dinero.js/currencies@2.0.0-alpha.14':
-    resolution: {integrity: sha512-Ck5ZLjRI7Pl7Y4VkeOst4WEwiN5vZezv8GHcXWsVLUfTNsmkV37VeLYDRAuTUP4akEJyIry+1o1qHYNtLq3eNw==}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -6304,6 +6286,7 @@ packages:
   aws-sdk@2.1311.0:
     resolution: {integrity: sha512-X3cFNsfs3HUfz6LKiLqvDTO4EsqO5DnNssh9SOoxhwmoMyJ2et3dEmigO6TaA44BjVNdLW98+sXJVPTGvINY1Q==}
     engines: {node: '>= 10.0.0'}
+    deprecated: The AWS SDK for JavaScript (v2) has reached end-of-support, and no longer receives updates. Please migrate your code to use AWS SDK for JavaScript (v3). More info https://a.co/cUPnyil
 
   axios@1.10.0:
     resolution: {integrity: sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==}
@@ -6391,6 +6374,7 @@ packages:
   basic-ftp@5.1.0:
     resolution: {integrity: sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.0, please upgrade
 
   bcryptjs@3.0.3:
     resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
@@ -7273,8 +7257,9 @@ packages:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
 
-  dinero.js@2.0.0-alpha.14:
-    resolution: {integrity: sha512-dkURHd9P+2TjuSTMUAnvrB7SsL4GbBYG/WPtIBV8M+L7Xf80x84sJcUUTxIS33S4AlkIbVANlaL86w2g5zdrmg==}
+  dinero.js@2.0.0:
+    resolution: {integrity: sha512-UTbFNSTA+7PBFQrubw004/mGxH8GPLL7a4NKoZJGISd9Pwe9YQsxJw+gO5kYRef0EiMLOptE6DH1mMBev7eQjQ==}
+    engines: {node: '>=20.0.0'}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -13368,16 +13353,6 @@ snapshots:
       '@depot/cli-win32-ia32': 0.0.1-cli.2.80.0
       '@depot/cli-win32-x64': 0.0.1-cli.2.80.0
 
-  '@dinero.js/calculator-number@2.0.0-alpha.14':
-    dependencies:
-      '@dinero.js/core': 2.0.0-alpha.14
-
-  '@dinero.js/core@2.0.0-alpha.14':
-    dependencies:
-      '@dinero.js/currencies': 2.0.0-alpha.14
-
-  '@dinero.js/currencies@2.0.0-alpha.14': {}
-
   '@dnd-kit/accessibility@3.1.1(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -14118,51 +14093,51 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
-  '@inquirer/checkbox@4.3.2(@types/node@20.19.33)':
+  '@inquirer/checkbox@4.3.2(@types/node@20.11.24)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@20.19.33)
+      '@inquirer/core': 10.3.2(@types/node@20.11.24)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@20.19.33)
+      '@inquirer/type': 3.0.10(@types/node@20.11.24)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 20.19.33
+      '@types/node': 20.11.24
 
-  '@inquirer/confirm@5.1.21(@types/node@20.19.33)':
+  '@inquirer/confirm@5.1.21(@types/node@20.11.24)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@20.19.33)
-      '@inquirer/type': 3.0.10(@types/node@20.19.33)
+      '@inquirer/core': 10.3.2(@types/node@20.11.24)
+      '@inquirer/type': 3.0.10(@types/node@20.11.24)
     optionalDependencies:
-      '@types/node': 20.19.33
+      '@types/node': 20.11.24
 
-  '@inquirer/core@10.3.2(@types/node@20.19.33)':
+  '@inquirer/core@10.3.2(@types/node@20.11.24)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@20.19.33)
+      '@inquirer/type': 3.0.10(@types/node@20.11.24)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 20.19.33
+      '@types/node': 20.11.24
 
-  '@inquirer/editor@4.2.23(@types/node@20.19.33)':
+  '@inquirer/editor@4.2.23(@types/node@20.11.24)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@20.19.33)
-      '@inquirer/external-editor': 1.0.3(@types/node@20.19.33)
-      '@inquirer/type': 3.0.10(@types/node@20.19.33)
+      '@inquirer/core': 10.3.2(@types/node@20.11.24)
+      '@inquirer/external-editor': 1.0.3(@types/node@20.11.24)
+      '@inquirer/type': 3.0.10(@types/node@20.11.24)
     optionalDependencies:
-      '@types/node': 20.19.33
+      '@types/node': 20.11.24
 
-  '@inquirer/expand@4.0.23(@types/node@20.19.33)':
+  '@inquirer/expand@4.0.23(@types/node@20.11.24)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@20.19.33)
-      '@inquirer/type': 3.0.10(@types/node@20.19.33)
+      '@inquirer/core': 10.3.2(@types/node@20.11.24)
+      '@inquirer/type': 3.0.10(@types/node@20.11.24)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 20.19.33
+      '@types/node': 20.11.24
 
   '@inquirer/external-editor@1.0.3(@types/node@20.11.24)':
     dependencies:
@@ -14171,82 +14146,75 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.11.24
 
-  '@inquirer/external-editor@1.0.3(@types/node@20.19.33)':
-    dependencies:
-      chardet: 2.1.1
-      iconv-lite: 0.7.2
-    optionalDependencies:
-      '@types/node': 20.19.33
-
   '@inquirer/figures@1.0.15': {}
 
-  '@inquirer/input@4.3.1(@types/node@20.19.33)':
+  '@inquirer/input@4.3.1(@types/node@20.11.24)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@20.19.33)
-      '@inquirer/type': 3.0.10(@types/node@20.19.33)
+      '@inquirer/core': 10.3.2(@types/node@20.11.24)
+      '@inquirer/type': 3.0.10(@types/node@20.11.24)
     optionalDependencies:
-      '@types/node': 20.19.33
+      '@types/node': 20.11.24
 
-  '@inquirer/number@3.0.23(@types/node@20.19.33)':
+  '@inquirer/number@3.0.23(@types/node@20.11.24)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@20.19.33)
-      '@inquirer/type': 3.0.10(@types/node@20.19.33)
+      '@inquirer/core': 10.3.2(@types/node@20.11.24)
+      '@inquirer/type': 3.0.10(@types/node@20.11.24)
     optionalDependencies:
-      '@types/node': 20.19.33
+      '@types/node': 20.11.24
 
-  '@inquirer/password@4.0.23(@types/node@20.19.33)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@20.19.33)
-      '@inquirer/type': 3.0.10(@types/node@20.19.33)
-    optionalDependencies:
-      '@types/node': 20.19.33
-
-  '@inquirer/prompts@7.9.0(@types/node@20.19.33)':
-    dependencies:
-      '@inquirer/checkbox': 4.3.2(@types/node@20.19.33)
-      '@inquirer/confirm': 5.1.21(@types/node@20.19.33)
-      '@inquirer/editor': 4.2.23(@types/node@20.19.33)
-      '@inquirer/expand': 4.0.23(@types/node@20.19.33)
-      '@inquirer/input': 4.3.1(@types/node@20.19.33)
-      '@inquirer/number': 3.0.23(@types/node@20.19.33)
-      '@inquirer/password': 4.0.23(@types/node@20.19.33)
-      '@inquirer/rawlist': 4.1.11(@types/node@20.19.33)
-      '@inquirer/search': 3.2.2(@types/node@20.19.33)
-      '@inquirer/select': 4.4.2(@types/node@20.19.33)
-    optionalDependencies:
-      '@types/node': 20.19.33
-
-  '@inquirer/rawlist@4.1.11(@types/node@20.19.33)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@20.19.33)
-      '@inquirer/type': 3.0.10(@types/node@20.19.33)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 20.19.33
-
-  '@inquirer/search@3.2.2(@types/node@20.19.33)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@20.19.33)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@20.19.33)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 20.19.33
-
-  '@inquirer/select@4.4.2(@types/node@20.19.33)':
+  '@inquirer/password@4.0.23(@types/node@20.11.24)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@20.19.33)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@20.19.33)
+      '@inquirer/core': 10.3.2(@types/node@20.11.24)
+      '@inquirer/type': 3.0.10(@types/node@20.11.24)
+    optionalDependencies:
+      '@types/node': 20.11.24
+
+  '@inquirer/prompts@7.9.0(@types/node@20.11.24)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@20.11.24)
+      '@inquirer/confirm': 5.1.21(@types/node@20.11.24)
+      '@inquirer/editor': 4.2.23(@types/node@20.11.24)
+      '@inquirer/expand': 4.0.23(@types/node@20.11.24)
+      '@inquirer/input': 4.3.1(@types/node@20.11.24)
+      '@inquirer/number': 3.0.23(@types/node@20.11.24)
+      '@inquirer/password': 4.0.23(@types/node@20.11.24)
+      '@inquirer/rawlist': 4.1.11(@types/node@20.11.24)
+      '@inquirer/search': 3.2.2(@types/node@20.11.24)
+      '@inquirer/select': 4.4.2(@types/node@20.11.24)
+    optionalDependencies:
+      '@types/node': 20.11.24
+
+  '@inquirer/rawlist@4.1.11(@types/node@20.11.24)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@20.11.24)
+      '@inquirer/type': 3.0.10(@types/node@20.11.24)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 20.19.33
+      '@types/node': 20.11.24
 
-  '@inquirer/type@3.0.10(@types/node@20.19.33)':
+  '@inquirer/search@3.2.2(@types/node@20.11.24)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@20.11.24)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@20.11.24)
+      yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 20.19.33
+      '@types/node': 20.11.24
+
+  '@inquirer/select@4.4.2(@types/node@20.11.24)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@20.11.24)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@20.11.24)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 20.11.24
+
+  '@inquirer/type@3.0.10(@types/node@20.11.24)':
+    optionalDependencies:
+      '@types/node': 20.11.24
 
   '@ioredis/commands@1.5.0': {}
 
@@ -14418,15 +14386,15 @@ snapshots:
       '@types/react': 18.3.28
       react: 19.2.3
 
-  '@mintlify/cli@4.0.957(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/node@20.19.33)(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)':
+  '@mintlify/cli@4.0.957(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/node@20.11.24)(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@inquirer/prompts': 7.9.0(@types/node@20.19.33)
-      '@mintlify/common': 1.0.731(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
-      '@mintlify/link-rot': 3.0.892(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
+      '@inquirer/prompts': 7.9.0(@types/node@20.11.24)
+      '@mintlify/common': 1.0.731(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))(typescript@5.9.3)
+      '@mintlify/link-rot': 3.0.892(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))(typescript@5.9.3)
       '@mintlify/models': 0.0.272
-      '@mintlify/prebuild': 1.0.868(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
-      '@mintlify/previewing': 4.0.925(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
-      '@mintlify/scraping': 4.0.593(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
+      '@mintlify/prebuild': 1.0.868(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))(typescript@5.9.3)
+      '@mintlify/previewing': 4.0.925(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))(typescript@5.9.3)
+      '@mintlify/scraping': 4.0.593(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))(typescript@5.9.3)
       '@mintlify/validation': 0.1.596(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       adm-zip: 0.5.16
       chalk: 5.2.0
@@ -14435,7 +14403,7 @@ snapshots:
       front-matter: 4.0.2
       fs-extra: 11.2.0
       ink: 6.3.0(@types/react@18.3.28)(react@19.2.3)
-      inquirer: 12.3.0(@types/node@20.19.33)
+      inquirer: 12.3.0(@types/node@20.11.24)
       js-yaml: 4.1.0
       mdast-util-mdx-jsx: 3.2.0
       react: 19.2.3
@@ -14459,7 +14427,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@mintlify/common@1.0.661(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)':
+  '@mintlify/common@1.0.661(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@asyncapi/parser': 3.4.0(encoding@0.1.13)
       '@mintlify/mdx': 3.0.4(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
@@ -14499,7 +14467,7 @@ snapshots:
       remark-parse: 11.0.0
       remark-rehype: 11.1.1
       remark-stringify: 11.0.0
-      tailwindcss: 3.4.4(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))
+      tailwindcss: 3.4.4(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))
       unified: 11.0.5
       unist-builder: 4.0.0
       unist-util-map: 4.0.0
@@ -14519,7 +14487,7 @@ snapshots:
       - ts-node
       - typescript
 
-  '@mintlify/common@1.0.731(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)':
+  '@mintlify/common@1.0.731(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@asyncapi/parser': 3.4.0(encoding@0.1.13)
       '@asyncapi/specs': 6.8.1
@@ -14560,7 +14528,7 @@ snapshots:
       remark-parse: 11.0.0
       remark-rehype: 11.1.1
       remark-stringify: 11.0.0
-      tailwindcss: 3.4.4(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))
+      tailwindcss: 3.4.4(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))
       unified: 11.0.5
       unist-builder: 4.0.0
       unist-util-map: 4.0.0
@@ -14580,12 +14548,12 @@ snapshots:
       - ts-node
       - typescript
 
-  '@mintlify/link-rot@3.0.892(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)':
+  '@mintlify/link-rot@3.0.892(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@mintlify/common': 1.0.731(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
-      '@mintlify/prebuild': 1.0.868(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
-      '@mintlify/previewing': 4.0.925(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
-      '@mintlify/scraping': 4.0.522(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
+      '@mintlify/common': 1.0.731(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))(typescript@5.9.3)
+      '@mintlify/prebuild': 1.0.868(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))(typescript@5.9.3)
+      '@mintlify/previewing': 4.0.925(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))(typescript@5.9.3)
+      '@mintlify/scraping': 4.0.522(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))(typescript@5.9.3)
       '@mintlify/validation': 0.1.596(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       fs-extra: 11.1.0
       unist-util-visit: 4.1.2
@@ -14655,11 +14623,11 @@ snapshots:
       leven: 4.1.0
       yaml: 2.8.2
 
-  '@mintlify/prebuild@1.0.868(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)':
+  '@mintlify/prebuild@1.0.868(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@mintlify/common': 1.0.731(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
+      '@mintlify/common': 1.0.731(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))(typescript@5.9.3)
       '@mintlify/openapi-parser': 0.0.8
-      '@mintlify/scraping': 4.0.593(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
+      '@mintlify/scraping': 4.0.593(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))(typescript@5.9.3)
       '@mintlify/validation': 0.1.596(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       chalk: 5.3.0
       favicons: 7.2.0
@@ -14687,10 +14655,10 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@mintlify/previewing@4.0.925(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)':
+  '@mintlify/previewing@4.0.925(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@mintlify/common': 1.0.731(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
-      '@mintlify/prebuild': 1.0.868(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
+      '@mintlify/common': 1.0.731(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))(typescript@5.9.3)
+      '@mintlify/prebuild': 1.0.868(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))(typescript@5.9.3)
       '@mintlify/validation': 0.1.596(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       better-opn: 3.0.2
       chalk: 5.2.0
@@ -14725,9 +14693,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@mintlify/scraping@4.0.522(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)':
+  '@mintlify/scraping@4.0.522(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@mintlify/common': 1.0.661(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
+      '@mintlify/common': 1.0.661(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))(typescript@5.9.3)
       '@mintlify/openapi-parser': 0.0.8
       fs-extra: 11.1.1
       hast-util-to-mdast: 10.1.0
@@ -14760,9 +14728,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@mintlify/scraping@4.0.593(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)':
+  '@mintlify/scraping@4.0.593(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@mintlify/common': 1.0.731(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
+      '@mintlify/common': 1.0.731(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))(typescript@5.9.3)
       '@mintlify/openapi-parser': 0.0.8
       fs-extra: 11.1.1
       hast-util-to-mdast: 10.1.0
@@ -17449,15 +17417,15 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@tailwindcss/forms@0.5.11(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3)))':
+  '@tailwindcss/forms@0.5.11(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3)))':
     dependencies:
       mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.4.1(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))
+      tailwindcss: 3.4.1(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))
 
-  '@tailwindcss/typography@0.5.19(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3)))':
+  '@tailwindcss/typography@0.5.19(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3)))':
     dependencies:
       postcss-selector-parser: 6.0.10
-      tailwindcss: 3.4.1(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))
+      tailwindcss: 3.4.1(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))
 
   '@tailwindcss/typography@0.5.19(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -19241,11 +19209,7 @@ snapshots:
 
   diff@4.0.4: {}
 
-  dinero.js@2.0.0-alpha.14:
-    dependencies:
-      '@dinero.js/calculator-number': 2.0.0-alpha.14
-      '@dinero.js/core': 2.0.0-alpha.14
-      '@dinero.js/currencies': 2.0.0-alpha.14
+  dinero.js@2.0.0: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -20798,12 +20762,12 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
-  inquirer@12.3.0(@types/node@20.19.33):
+  inquirer@12.3.0(@types/node@20.11.24):
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@20.19.33)
-      '@inquirer/prompts': 7.9.0(@types/node@20.19.33)
-      '@inquirer/type': 3.0.10(@types/node@20.19.33)
-      '@types/node': 20.19.33
+      '@inquirer/core': 10.3.2(@types/node@20.11.24)
+      '@inquirer/prompts': 7.9.0(@types/node@20.11.24)
+      '@inquirer/type': 3.0.10(@types/node@20.11.24)
+      '@types/node': 20.11.24
       ansi-escapes: 4.3.2
       mute-stream: 2.0.0
       run-async: 3.0.0
@@ -22055,9 +22019,9 @@ snapshots:
     dependencies:
       minipass: 7.1.2
 
-  mint@4.2.354(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/node@20.19.33)(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3):
+  mint@4.2.354(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/node@20.11.24)(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
-      '@mintlify/cli': 4.0.957(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/node@20.19.33)(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
+      '@mintlify/cli': 4.0.957(@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/node@20.11.24)(@types/react@18.3.28)(encoding@0.1.13)(react-dom@18.3.1(react@19.2.3))(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))(typescript@5.9.3)
     transitivePeerDependencies:
       - '@radix-ui/react-popover'
       - '@types/node'
@@ -22880,13 +22844,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.6
 
-  postcss-load-config@4.0.2(postcss@8.4.35)(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3)):
+  postcss-load-config@4.0.2(postcss@8.4.35)(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.2
     optionalDependencies:
       postcss: 8.4.35
-      ts-node: 10.9.2(@types/node@20.19.33)(typescript@5.9.3)
+      ts-node: 10.9.2(@types/node@20.11.24)(typescript@5.9.3)
 
   postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
@@ -24490,15 +24454,15 @@ snapshots:
 
   tailwind-merge@2.6.1: {}
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))):
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))):
     dependencies:
-      tailwindcss: 3.4.1(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))
+      tailwindcss: 3.4.1(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))
 
   tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.2)
 
-  tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3)):
+  tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -24517,7 +24481,7 @@ snapshots:
       postcss: 8.4.35
       postcss-import: 15.1.0(postcss@8.4.35)
       postcss-js: 4.1.0(postcss@8.4.35)
-      postcss-load-config: 4.0.2(postcss@8.4.35)(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))
+      postcss-load-config: 4.0.2(postcss@8.4.35)(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))
       postcss-nested: 6.2.0(postcss@8.4.35)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
@@ -24553,7 +24517,7 @@ snapshots:
       - tsx
       - yaml
 
-  tailwindcss@3.4.4(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3)):
+  tailwindcss@3.4.4(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -24572,7 +24536,7 @@ snapshots:
       postcss: 8.4.35
       postcss-import: 15.1.0(postcss@8.4.35)
       postcss-js: 4.1.0(postcss@8.4.35)
-      postcss-load-config: 4.0.2(postcss@8.4.35)(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))
+      postcss-load-config: 4.0.2(postcss@8.4.35)(ts-node@10.9.2(@types/node@20.11.24)(typescript@5.9.3))
       postcss-nested: 6.2.0(postcss@8.4.35)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
@@ -24801,25 +24765,6 @@ snapshots:
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-
-  ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.33
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 5.9.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
 
   tsafe@1.8.12: {}
 


### PR DESCRIPTION
## Summary

Upgrades dinero.js from the v2 alpha (`2.0.0-alpha.14`) to the stable release (`2.0.0`).

The v2 stable consolidates all scoped alpha packages into a single `dinero.js` package:

- `dinero.js`: `2.0.0-alpha.14` -> `2.0.0`
- `@dinero.js/currencies` -> `dinero.js/currencies` (now a subpath export)
- Removes `@dinero.js/currencies` as a separate dependency in `apps/nextjs`, `internal/db`, and `internal/trpc`

No API changes: all existing `dinero`, `toDecimal`, `isZero`, `multiply`, `add`, `trimScale`, and currency imports work the same way.

**Release blog post:** https://www.sarahdayan.com/blog/dinerojs-v2-is-out
**Migration guide:** https://www.dinerojs.com/getting-started/upgrade-guide#migrating-from-v2-alpha

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dinero.js library to stable version 2.0.0 from pre-release.
  * Restructured currency module dependencies across applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->